### PR TITLE
Add FirewallRule property to ServerProperty in the inframodel package

### DIFF
--- a/infra/onprem/inframodel.go
+++ b/infra/onprem/inframodel.go
@@ -1,0 +1,11 @@
+package inframodel
+
+type OnpremiseInfraModel struct {
+	OnpremiseInfraModel OnpremInfra `json:"onpremiseInfraModel" validate:"required"`
+}
+
+type OnpremInfra struct {
+	Network NetworkProperty  `json:"network,omitempty"`
+	Servers []ServerProperty `json:"servers" validate:"required"`
+	// TODO: Add other fields
+}

--- a/infra/onprem/network.go
+++ b/infra/onprem/network.go
@@ -1,0 +1,7 @@
+package inframodel
+
+type NetworkProperty struct { // note: referrence command `ip route`
+	IPv4Networks  []string 		 `json:"ipv4Networks,omitempty" example:"172.26.240.0/20"`
+	IPv6Networks  []string 		 `json:"ipv6Networks,omitempty"` // TBD
+	// TODO: Add or update fields
+}

--- a/infra/onprem/server.go
+++ b/infra/onprem/server.go
@@ -1,35 +1,15 @@
 package inframodel
 
-type OnpremiseInfraModel struct {
-	OnpremiseInfraModel OnpremInfra `json:"onpremiseInfraModel" validate:"required"`
-}
-
-type OnpremInfra struct {
-	Network NetworkProperty  `json:"network,omitempty"`
-	Servers []ServerProperty `json:"servers" validate:"required"`
-	// TODO: Add other fields
-}
-
 type ServerProperty struct {
-	Hostname     string                     `json:"hostname"`
-	CPU          CpuProperty                `json:"cpu"`
-	Memory       MemoryProperty             `json:"memory"`
-	RootDisk     DiskProperty               `json:"rootDisk"`
-	DataDisks    []DiskProperty             `json:"dataDisks,omitempty"`
-	Interfaces   []NetworkInterfaceProperty `json:"interfaces"`
-	RoutingTable []RouteProperty            `json:"routingTable"`
-	OS           OsProperty                 `json:"os"`
-}
-
-type RouteProperty struct { // note: reference command `ip route`
-	Destination string `json:"destination,omitempty"` // Destination network, expressed in CIDR format
-	Gateway     string `json:"gateway,omitempty"`     // Gateway address to which packets are forwarded
-	Interface   string `json:"interface,omitempty"`   // Network interface associated with the route
-	Metric      int    `json:"metric,omitempty"`      // Metric value indicating the priority of the route
-	Protocol    string `json:"protocol,omitempty"`    // Protocol used to set the route (e.g., kernel, static)
-	Scope       string `json:"scope,omitempty"`       // Scope of the route (e.g., global, link, host)
-	Source      string `json:"source,omitempty"`      // Optionally stores the source address (used for policy-based routing)
-	LinkState   string `json:"linkState,omitempty"`   // Link state of the route (e.g., UP, DOWN)
+	Hostname      string                      `json:"hostname"`
+	CPU           CpuProperty                 `json:"cpu"`
+	Memory        MemoryProperty              `json:"memory"`
+	RootDisk      DiskProperty                `json:"rootDisk"`
+	DataDisks     []DiskProperty              `json:"dataDisks,omitempty"`
+	Interfaces    []NetworkInterfaceProperty  `json:"interfaces"`
+	RoutingTable  []RouteProperty             `json:"routingTable"`
+	FirewallRules []FirewallRuleProperty 	  `json:"firewallRules,omitempty"`
+	OS            OsProperty                  `json:"os"`
 }
 
 type CpuProperty struct {
@@ -68,6 +48,27 @@ type NetworkInterfaceProperty struct { // note: reference command `ifconfig`
 	// TODO: Add or update fields (e.g., )
 }
 
+type RouteProperty struct { // note: reference command `ip route`
+	Destination string `json:"destination,omitempty"` // Destination network, expressed in CIDR format
+	Gateway     string `json:"gateway,omitempty"`     // Gateway address to which packets are forwarded
+	Interface   string `json:"interface,omitempty"`   // Network interface associated with the route
+	Metric      int    `json:"metric,omitempty"`      // Metric value indicating the priority of the route
+	Protocol    string `json:"protocol,omitempty"`    // Protocol used to set the route (e.g., kernel, static)
+	Scope       string `json:"scope,omitempty"`       // Scope of the route (e.g., global, link, host)
+	Source      string `json:"source,omitempty"`      // Optionally stores the source address (used for policy-based routing)
+	LinkState   string `json:"linkState,omitempty"`   // Link state of the route (e.g., UP, DOWN)
+}
+
+type FirewallRuleProperty struct { // note: reference command `sudo ufw status verbose`
+	SrcCIDR   string `json:"srcCIDR,omitempty"`
+	DstCIDR   string `json:"dstCIDR,omitempty"`
+	SrcPorts  string `json:"srcPorts,omitempty"`
+	DstPorts  string `json:"dstPorts,omitempty"`
+	Protocol  string `json:"protocol,omitempty"`  // TCP, UDP, ICMP
+	Direction string `json:"direction,omitempty"` // inbound, outbound
+	Action    string `json:"action,omitempty"`    // allow, deny
+}
+
 type OsProperty struct { // note: reference command `cat /etc/os-release`
 	PrettyName      string `json:"prettyName" validate:"required" example:"Ubuntu 22.04.3 LTS"` // Pretty name
 	Version         string `json:"version,omitempty" example:"22.04.3 LTS (Jammy Jellyfish)"`   // Full version string
@@ -76,10 +77,4 @@ type OsProperty struct { // note: reference command `cat /etc/os-release`
 	VersionCodename string `json:"versionCodename,omitempty" example:"jammy"`
 	ID              string `json:"id,omitempty" example:"ubuntu"`
 	IDLike          string `json:"idLike,omitempty" example:"debian"`
-}
-
-type NetworkProperty struct { // note: referrence command `ip route`
-	IPv4Networks []string `json:"ipv4Networks,omitempty" example:"172.26.240.0/20"`
-	IPv6Networks []string `json:"ipv6Networks,omitempty"` // TBD
-	// TODO: Add or update fields
 }


### PR DESCRIPTION
- Add FirewallRule property to ServerProperty in the inframodel package (In ./cm-model/infra/onprem directory)
- Divide onpremise.go file into inframodel.go, network.go and server.go files In ./cm-model/infra/onprem directory
- Add go.sum file
- Remove .keep file In ./cm-model/infra directory