### PR TITLE
Improve the struct (schema) representing the network

### DIFF
--- a/infra/onprem/network.go
+++ b/infra/onprem/network.go
@@ -1,7 +1,24 @@
 package inframodel
 
-type NetworkProperty struct { // note: referrence command `ip route`
-	IPv4Networks  []string 		 `json:"ipv4Networks,omitempty" example:"172.26.240.0/20"`
-	IPv6Networks  []string 		 `json:"ipv6Networks,omitempty"` // TBD
+// NetworkProerty represents a network for on-premise infrastructure.
+// In other perspective, it can be a network for servers and/or a collection of networks extracted from a host.//
+// * [Important] Information in the IPv4Networks list should be as non-duplicated as possible.
+type NetworkProperty struct { // note: reference command `ip route`, `netstat -rn`, and `lshw -c network`
+	IPv4Networks []NetworkDetail `json:"ipv4Networks,omitempty"`
+	IPv6Networks []NetworkDetail `json:"ipv6Networks,omitempty"` // TBD
 	// TODO: Add or update fields
+}
+
+// NetworkDetail represents DefaultGateway and DefaultRouteInterface
+// - DefaultGateway info: extracted from a host.
+// - DefaultRouteInterface info: extracted from a host based on "the DefaultGateway IFace name".
+type NetworkDetail struct {
+	DefaultGateway        GatewayProperty          `json:"gateway,omitempty"`
+	DefaultRouteInterface NetworkInterfaceProperty `json:"defaultRouteInterface,omitempty"`
+}
+
+type GatewayProperty struct {
+	IP            string `json:"ip,omitempty" example:"192.168.1.1"`
+	InterfaceName string `json:"interfaceName,omitempty" example:"eth0"`
+	Metric        int    `json:"metric,omitempty" example:"100"`
 }

--- a/infra/onprem/server.go
+++ b/infra/onprem/server.go
@@ -1,15 +1,15 @@
 package inframodel
 
 type ServerProperty struct {
-	Hostname      string                      `json:"hostname"`
-	CPU           CpuProperty                 `json:"cpu"`
-	Memory        MemoryProperty              `json:"memory"`
-	RootDisk      DiskProperty                `json:"rootDisk"`
-	DataDisks     []DiskProperty              `json:"dataDisks,omitempty"`
-	Interfaces    []NetworkInterfaceProperty  `json:"interfaces"`
-	RoutingTable  []RouteProperty             `json:"routingTable"`
-	FirewallRules []FirewallRuleProperty 	  `json:"firewallRules,omitempty"`
-	OS            OsProperty                  `json:"os"`
+	Hostname      string                     `json:"hostname"`
+	CPU           CpuProperty                `json:"cpu"`
+	Memory        MemoryProperty             `json:"memory"`
+	RootDisk      DiskProperty               `json:"rootDisk"`
+	DataDisks     []DiskProperty             `json:"dataDisks,omitempty"`
+	Interfaces    []NetworkInterfaceProperty `json:"interfaces"`
+	RoutingTable  []RouteProperty            `json:"routingTable"`
+	FirewallRules []FirewallRuleProperty     `json:"firewallRules,omitempty"`
+	OS            OsProperty                 `json:"os"`
 }
 
 type CpuProperty struct {


### PR DESCRIPTION
이 PR에서 VPC, Subnet 추천 기능 구현을 위해 **기존 네트워크에 대한 모델 규격(schema, struct)를 개선**하고자 합니다.

@ish-hcc (cc. @innodreamer @hanizang77)

Honeybee와 연관된 부분이 있어 아래 "네트워크 구조체 개선 사항"에 대해 검토를 부탁드립니다 :) 
("배경" 부분은 가볍게 살펴보시면 될 것 같습니다.)

### 배경
현재 추출되는 정보는 Host (Server) 내부에서 사용하는 네트워크 정보이고, Host 가 존재하는 상위 네트워크에 대한 정보 또는 상위 네트워크를 추정할 수 있는 정보가 아닌 것으로 판단됩니다.

Host에 Agent를 설치하여 정보를 추출하는 상황에서 상위 네트워크 자체에 대한 정보를 얻는 것은 어려울 것 같고, 이는 Onpremise 관리자가 입력해야하는 값이라는 생각도 듭니다.

한편, Agent에서 정보를 추출하는 현 상황에서 적용할 수 있는 방안을 공유드립니다. **상위 네트워크를 정보를 추정할 수 있는 정보들이 제공되면 이를 바탕으로 상위 네트워크를 추정하여 VPC/Subnet 추천하는 방안을 고려해 볼 수 있겠습니다.**

현재 추출되는 정보는 아래와 같고요. <ins>Honeybee에서 정보 매칭 부분에 대해 보완을 부탁드려야 할 것 같습니다.</ins>

```json
{
  "onpremiseInfraModel": {
    "network": {
      "ipv4Networks": [
        "10.0.0.0/24",
        "192.168.110.0/24",
        "172.17.0.0/16",
        "172.16.0.128/32",
        "172.16.0.80/32",
        "172.29.0.0/24",
        "172.18.0.0/16",
        "172.21.0.0/16",
        "172.22.0.0/16"
      ],
      "ipv6Networks": ["fe80::/64"]
    },
    ....
}
```

모델 규격(schema, struct) 참고: 

https://github.com/cloud-barista/cm-model/blob/ce15d81d44c2b8aeef42f63def617523efb3e71b/infra/onprem/inframodel.go#L7-L11


### 네트워크 구조체 개선 사항

(요약)
* Host에서 추출할 수 있는 정보를 분석하여 상위 네트워크를 추정할 수 있는 정보들이 무엇인지 정리해 보았습니다.
* 모든 Host에서 Gateway 정보 및 (Gateway 정보 내에 포함된) IFace 정보를 추출하고,
* (가능한) 중복을 제거하여 제공된다면 이를 바탕으로 상위 네트워크를 추정할 가능성이 높다고 판단했습니다.
* 추정을 통해 얻은 상위 네트워크 CIDR Block은 VPC 및 Subnet 추천에 활용할 수 있을 것 입니다.

**이를 위해, 이번 PR에서 NetworkProperty를 개선하고자 합니다.** 

분석에 활용된 명령어 및 결과가 다음과 같습니다. 
* WSL2 환경에서 수행한 결과입니다.
* Honeybee에서 추출하는 정보와 다를 수 있어 참고만 하시면 될 것 같습니다.

<details>
<summary>Click me</summary>

: (첫 번째 줄) DefaultGateway 정보 및 DefaultRouteInterface 정보 (i.e., eth0)
```shell
ip route
default via 172.26.240.1 dev eth0 proto kernel
172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 linkdown
172.18.0.0/16 dev br-2caca1987bee proto kernel scope link src 172.18.0.1 linkdown
172.19.0.0/16 dev br-63c32fd4cfbb proto kernel scope link src 172.19.0.1 linkdown
172.20.0.0/16 dev br-f608768f2736 proto kernel scope link src 172.20.0.1 linkdown
172.21.0.0/16 dev br-45181079ed48 proto kernel scope link src 172.21.0.1 linkdown
172.23.0.0/16 dev br-35c49a33050b proto kernel scope link src 172.23.0.1 linkdown
172.26.240.0/20 dev eth0 proto kernel scope link src 172.26.253.17
```

: (첫 번째 줄) DefaultGateway 정보 및 DefaultRouteInterface 정보 (i.e., eth0)
```shell
netstat -rn
Kernel IP routing table
Destination     Gateway         Genmask         Flags   MSS Window  irtt Iface
0.0.0.0         172.26.240.1    0.0.0.0         UG        0 0          0 eth0
172.17.0.0      0.0.0.0         255.255.0.0     U         0 0          0 docker0
172.18.0.0      0.0.0.0         255.255.0.0     U         0 0          0 br-2caca1987bee
172.19.0.0      0.0.0.0         255.255.0.0     U         0 0          0 br-63c32fd4cfbb
172.20.0.0      0.0.0.0         255.255.0.0     U         0 0          0 br-f608768f2736
172.21.0.0      0.0.0.0         255.255.0.0     U         0 0          0 br-45181079ed48
172.23.0.0      0.0.0.0         255.255.0.0     U         0 0          0 br-35c49a33050b
172.26.240.0    0.0.0.0         255.255.240.0   U         0 0          0 eth0
```

: Host에서 외부로 연결되는 네트워크 인터페이스 정보 (logical name: eth0)
```shell
lshw -c network
WARNING: you should run this program as super-user.
  *-network
       description: Ethernet interface
       physical id: 1
       logical name: eth0
       serial: 00:15:5d:d0:a5:80
       size: 10Gbit/s
       capabilities: ethernet physical
       configuration: autonegotiation=off broadcast=yes driver=hv_netvsc driverversion=5.15.167.4-microsoft-standard-W duplex=full firmware=N/A ip=172.26.253.17 link=yes multicast=yes speed=10Gbit/s
WARNING: output may be incomplete or inaccurate, you should run this program as super-user.
```

</details>
