### PR TITLE
Update the cloud model

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ cm-model/
 │   ├── cloud-model/          # Cloud infrastructure models
 │   └── on-premise-model/     # On-premise infrastructure models
 ├── sw/                       # Software models
+├── scripts/                  # Utility scripts for analysis and maintenance
 ├── data/                     # Data storage (for future use)
 └── go.mod
 ```
@@ -50,3 +51,11 @@ replace github.com/cloud-barista/cm-model => ../cm-model
 ```
 
 Once you've tested your changes, contribute them back to the upstream cm-model repository.
+
+## Development Tools
+
+### Dependency Analysis
+
+Use the dependency analyzer script to understand struct relationships across the entire cloudmodel package and find unused components.
+
+See [`scripts/README.md`](scripts/README.md) for detailed documentation on available analysis tools.

--- a/infra/cloud-model/model.go
+++ b/infra/cloud-model/model.go
@@ -7,21 +7,28 @@ type RecommendedVmInfraModel struct {
 
 // RecommendedVmInfra represents the recommended virtual machine infrastructure information.
 type RecommendedVmInfra struct {
-	Status                  string               `json:"status"`
-	Description             string               `json:"description"`
-	TargetVmInfra           TbMciReq             `json:"targetVmInfra"`
-	TargetVNet              TbVNetReq            `json:"targetVNet"`
-	TargetSshKey            TbSshKeyReq          `json:"targetSshKey"`
-	TargetVmSpecList        []TbSpecInfo         `json:"targetVmSpecList"`
-	TargetVmOsImageList     []TbImageInfo        `json:"targetVmOsImageList"`
-	TargetSecurityGroupList []TbSecurityGroupReq `json:"targetSecurityGroupList"`
+	Status                  string             `json:"status"`
+	Description             string             `json:"description"`
+	TargetCloud             CloudProperty      `json:"targetCloud"`
+	TargetVmInfra           MciReq             `json:"targetVmInfra"`
+	TargetVNet              VNetReq            `json:"targetVNet"`
+	TargetSshKey            SshKeyReq          `json:"targetSshKey"`
+	TargetVmSpecList        []SpecInfo         `json:"targetVmSpecList"`
+	TargetVmOsImageList     []ImageInfo        `json:"targetVmOsImageList"`
+	TargetSecurityGroupList []SecurityGroupReq `json:"targetSecurityGroupList"`
+}
+
+// CloudProperty represents the cloud service provider (CSP) information.
+type CloudProperty struct {
+	Csp    string `json:"csp" example:"aws"`
+	Region string `json:"region" example:"ap-northeast-2"`
 }
 
 // RecommendedVmInfraDynamic represents the recommended virtual machine infrastructure information.
 type RecommendedVmInfraDynamic struct {
-	Status        string          `json:"status"`
-	Description   string          `json:"description"`
-	TargetVmInfra TbMciDynamicReq `json:"targetVmInfra"`
+	Status        string        `json:"status"`
+	Description   string        `json:"description"`
+	TargetVmInfra MciDynamicReq `json:"targetVmInfra"`
 }
 
 // RecommendedVmInfraDynamicList represents a list of recommended virtual machine infrastructure information.
@@ -34,9 +41,9 @@ type RecommendedVmInfraDynamicList struct {
 // RecommendedVNet represents the recommended virtual network information.
 // * May be mainly used this object
 type RecommendedVNet struct {
-	Status      string    `json:"status"`
-	Description string    `json:"description"`
-	TargetVNet  TbVNetReq `json:"targetVNet"`
+	Status      string  `json:"status"`
+	Description string  `json:"description"`
+	TargetVNet  VNetReq `json:"targetVNet"`
 }
 
 // RecommendedVNetList represents a list of recommended virtual network information.
@@ -48,10 +55,10 @@ type RecommendedVNetList struct {
 
 // RecommendedSecurityGroup represents the recommended security group information.
 type RecommendedSecurityGroup struct {
-	Status              string             `json:"status"`
-	SourceServers       []string           `json:"sourceServers"`
-	Description         string             `json:"description"`
-	TargetSecurityGroup TbSecurityGroupReq `json:"targetSecurityGroup"`
+	Status              string           `json:"status"`
+	SourceServers       []string         `json:"sourceServers"`
+	Description         string           `json:"description"`
+	TargetSecurityGroup SecurityGroupReq `json:"targetSecurityGroup"`
 }
 
 // RecommendedSecurityGroupList represents a list of recommended security group information.
@@ -64,10 +71,10 @@ type RecommendedSecurityGroupList struct {
 
 // RecommendedVmSpec represents the recommended virtual machine specification information for a single server.
 type RecommendedVmSpec struct {
-	Status        string     `json:"status"`
-	SourceServers []string   `json:"sourceServers"`
-	Description   string     `json:"description"`
-	TargetVmSpec  TbSpecInfo `json:"targetVmSpec"`
+	Status        string   `json:"status"`
+	SourceServers []string `json:"sourceServers"`
+	Description   string   `json:"description"`
+	TargetVmSpec  SpecInfo `json:"targetVmSpec"`
 }
 
 // RecommendedVmSpecList represents a collection of recommended VM specifications across multiple source servers.
@@ -80,12 +87,12 @@ type RecommendedVmSpecList struct {
 
 // RecommendedVmOsImage represents the recommended virtual machine OS image information for a single server.
 type RecommendedVmOsImage struct {
-	Status          string      `json:"status"`
-	SourceServers   []string    `json:"sourceServers"`
-	Description     string      `json:"description"`
-	TargetVmOsImage TbImageInfo `json:"targetVmOsImage"`
+	Status          string    `json:"status"`
+	SourceServers   []string  `json:"sourceServers"`
+	Description     string    `json:"description"`
+	TargetVmOsImage ImageInfo `json:"targetVmOsImage"`
 	// Count            int                   `json:"count"`
-	// TargetVmOsImages []tbmodel.TbImageInfo `json:"targetVmOsImages"`
+	// TargetVmOsImages []ImageInfo `json:"targetVmOsImages"`
 }
 
 // RecommendedVmOsImageList represents a collection of recommended VM OS images across multiple source servers.

--- a/infra/cloud-model/vm-infra-info.go
+++ b/infra/cloud-model/vm-infra-info.go
@@ -5,11 +5,11 @@ package cloudmodel
 // }
 
 type VmInfraInfo struct {
-	TbMciInfo
+	MciInfo
 }
 
 type MciInfoList struct {
-	Mci []TbMciInfo `json:"mci"`
+	Mci []MciInfo `json:"mci"`
 }
 
 type IdList struct {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,177 @@
+# Scripts Directory
+
+This directory contains utility scripts for analyzing and managing the CB-Tumblebug model synchronization in the cm-model project.
+
+## Available Scripts
+
+### 🔍 `analyze_dependencies.py`
+
+Analyzes the struct dependencies across the entire `cloudmodel` package (`copied-tb-model.go`, `model.go`, and `vm-infra-info.go`) and provides comprehensive insights into struct relationships and usage patterns.
+
+#### Features
+
+- **Package-wide Analysis**: Analyzes all Go files in the `infra/cloud-model` directory
+- **Cross-file Dependencies**: Identifies dependencies between structs across different files
+- **Independence Detection**: Identifies structs with no dependencies on custom types
+- **Usage Tracking**: Checks which structs are referenced by other structs within the package
+- **File Location Tracking**: Shows which file each struct is defined in
+- **Cleanup Candidates**: Identifies completely unused structs across the entire package
+
+#### Usage
+
+```bash
+# Basic analysis (all files in cloudmodel package)
+python3 scripts/analyze_dependencies.py
+
+# Detailed analysis with dependency chains
+python3 scripts/analyze_dependencies.py --verbose
+
+# Show only unused structs (for cleanup)
+python3 scripts/analyze_dependencies.py --unused-only
+
+# Show only cross-file dependencies
+python3 scripts/analyze_dependencies.py --cross-file-only
+```
+
+#### Sample Output
+
+```
+🔍 CB-Tumblebug Model Dependency Analysis (CloudModel Package)
+=================================================================
+
+📊 Statistics:
+   Total files analyzed: 3
+   copied-tb-model.go: 25 structs, 3 string types
+   model.go: 12 structs, 0 string types
+   vm-infra-info.go: 4 structs, 0 string types
+   Package total: 41 structs, 3 string types, 44 custom types
+
+✅ INDEPENDENT STRUCTS (no dependencies on custom types) [16]:
+   • CreateSubGroupDynamicReq (defined in copied-tb-model.go)
+   • CreateSubGroupReq (defined in copied-tb-model.go)
+   • FirewallRuleReq (defined in copied-tb-model.go)
+   • KeyValue (defined in copied-tb-model.go)
+   • Location (defined in copied-tb-model.go)
+   • MciCmdReq (defined in copied-tb-model.go)
+   • RegionInfo (defined in copied-tb-model.go)
+   • SecurityGroupReq (defined in copied-tb-model.go)
+   ...
+
+🔗 STRUCTS WITH DEPENDENCIES [25]:
+   • ConnConfig (copied-tb-model.go) → RegionZoneInfo, RegionDetail
+   • ImageInfo (copied-tb-model.go) → OSArchitecture, OSPlatform, KeyValue, ImageStatus
+   • RecommendedVmInfra (model.go) → SecurityGroupReq, SpecInfo, VNetReq, ImageInfo, MciReq, SshKeyReq
+   ...
+
+🔄 CROSS-FILE DEPENDENCIES [7]:
+   • RecommendedVmInfra (model.go) → MciReq (copied-tb-model.go), SshKeyReq (copied-tb-model.go), ...
+   • RecommendedVmOsImage (model.go) → ImageInfo (copied-tb-model.go)
+   ...
+
+⚠️  COMPLETELY UNUSED STRUCTS [11]:
+   • FirewallRuleReq (defined in copied-tb-model.go)
+   • IdList (defined in vm-infra-info.go)
+   • MigratedVmInfraModel (defined in vm-infra-info.go)
+   ...
+```
+
+#### Command Line Options
+
+- `--verbose, -v`: Show detailed dependency information including reference chains and file locations
+- `--unused-only, -u`: Show only completely unused structs (useful for cleanup operations)
+- `--cross-file-only, -c`: Show only dependencies between structs in different files
+
+#### Use Cases
+
+1. **Before CB-Tumblebug Sync**: Understand current dependency structure across all cloudmodel files
+2. **Code Cleanup**: Identify unused structs that might be removed from any file
+3. **Refactoring**: Understand impact of struct changes across file boundaries
+4. **Architecture Review**: Analyze cross-file dependencies and coupling
+5. **Documentation**: Generate comprehensive dependency documentation
+6. **Quality Assurance**: Verify struct usage consistency across the package
+
+#### Requirements
+
+- Python 3.6+
+- Access to `infra/cloud-model/` directory with Go source files
+- Analyzes: `copied-tb-model.go`, `model.go`, `vm-infra-info.go`
+
+#### Technical Details
+
+The script uses regex patterns to:
+
+- Extract struct definitions: `type StructName struct`
+- Extract custom types: `type TypeName string`
+- Find field references: `FieldName CustomType` or `FieldName []CustomType`
+- Analyze dependency chains across multiple Go files in the cloudmodel package
+- Track cross-file dependencies to identify architectural coupling
+
+#### Integration with CI/CD
+
+This script can be integrated into automated workflows:
+
+```bash
+# Check for unused structs before merging
+python3 scripts/analyze_dependencies.py --unused-only
+
+# Check cross-file dependencies for architecture review
+python3 scripts/analyze_dependencies.py --cross-file-only
+
+# Generate comprehensive dependency report
+python3 scripts/analyze_dependencies.py --verbose > dependency_report.txt
+```
+
+## Script Development Guidelines
+
+### Adding New Scripts
+
+1. **Naming Convention**: Use snake_case for script files
+2. **Documentation**: Include docstring with usage examples
+3. **Error Handling**: Implement proper error handling and user feedback
+4. **CLI Interface**: Use `argparse` for command-line options
+5. **Project Root Detection**: Auto-detect project root via `go.mod`
+
+### Code Standards
+
+- Follow PEP 8 Python style guidelines
+- Include type hints where appropriate
+- Add comprehensive error handling
+- Provide helpful error messages
+- Support both verbose and quiet modes
+
+### Testing Scripts
+
+```bash
+# Test basic functionality
+cd /path/to/cm-model
+python3 scripts/analyze_dependencies.py
+
+# Test with different options
+python3 scripts/analyze_dependencies.py --verbose
+python3 scripts/analyze_dependencies.py --unused-only
+
+# Test error handling
+python3 scripts/analyze_dependencies.py --help
+```
+
+## Contributing
+
+When adding new analysis scripts:
+
+1. Follow the existing patterns in `analyze_dependencies.py`
+2. Add comprehensive documentation to this README
+3. Test scripts from different working directories
+4. Ensure scripts work with relative and absolute paths
+5. Add appropriate error handling for missing files
+6. Update this README with new script information
+
+## Future Enhancements
+
+Potential improvements for the dependency analyzer:
+
+- **Visualization**: Generate dependency graphs (GraphViz, Mermaid)
+- **Circular Dependency Detection**: Detect and report circular dependencies
+- **Impact Analysis**: Show impact of removing specific structs
+- **Version Comparison**: Compare dependencies between different versions
+- **Export Formats**: Support JSON, CSV, YAML output formats
+- **Web Interface**: Create web-based dependency browser

--- a/scripts/analyze_dependencies.py
+++ b/scripts/analyze_dependencies.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""
+CB-Tumblebug Model Dependency Analyzer
+
+This script analyzes the dependencies between structs in the cloudmodel package
+(copied-tb-model.go and model.go) and provides insights into struct relationships
+and usage patterns across the entire package.
+
+Usage:
+    python3 scripts/analyze_dependencies.py
+    python3 scripts/analyze_dependencies.py --verbose
+    python3 scripts/analyze_dependencies.py --unused-only
+"""
+
+import os
+import re
+import sys
+import argparse
+from pathlib import Path
+
+
+def find_project_root():
+    """Find the project root directory by looking for go.mod file."""
+    # Start from script directory
+    script_dir = Path(__file__).parent.parent
+    
+    # Check script's parent directory first (likely project root)
+    if (script_dir / "go.mod").exists():
+        return script_dir
+    
+    # Check current working directory and its parents
+    current = Path.cwd()
+    for parent in [current] + list(current.parents):
+        if (parent / "go.mod").exists():
+            return parent
+    
+    # Fallback to script's parent directory
+    return script_dir
+
+
+def extract_structs_and_types(content, file_name=""):
+    """Extract all struct names and custom type definitions from Go content."""
+    # Extract struct names
+    struct_pattern = r'type\s+(\w+)\s+struct'
+    all_structs = set(re.findall(struct_pattern, content))
+    
+    # Extract string type definitions
+    string_type_pattern = r'type\s+(\w+)\s+string'
+    string_types = set(re.findall(string_type_pattern, content))
+    
+    # Combine all custom types
+    all_types = all_structs | string_types
+    
+    return all_structs, string_types, all_types
+
+
+def read_cloudmodel_files(project_root):
+    """Read all files in the cloudmodel package."""
+    cloud_model_dir = project_root / "infra" / "cloud-model"
+    
+    files_data = {}
+    all_structs = set()
+    all_string_types = set()
+    all_types = set()
+    
+    # Files to analyze in the cloudmodel package
+    target_files = [
+        ("copied-tb-model.go", "CB-Tumblebug models"),
+        ("model.go", "CM-Model types"),
+        ("vm-infra-info.go", "VM infrastructure info")
+    ]
+    
+    for filename, description in target_files:
+        file_path = cloud_model_dir / filename
+        if file_path.exists():
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    content = f.read()
+                
+                structs, string_types, types = extract_structs_and_types(content, filename)
+                
+                files_data[filename] = {
+                    'content': content,
+                    'description': description,
+                    'structs': structs,
+                    'string_types': string_types,
+                    'types': types
+                }
+                
+                all_structs.update(structs)
+                all_string_types.update(string_types)
+                all_types.update(types)
+                
+            except Exception as e:
+                print(f"⚠️  Warning: Could not read {filename}: {e}")
+    
+    return files_data, all_structs, all_string_types, all_types
+
+
+def find_struct_dependencies_in_content(content, struct_name, all_types):
+    """Find dependencies for a specific struct within given content."""
+    # Extract the struct definition
+    struct_start = content.find(f'type {struct_name} struct')
+    if struct_start == -1:
+        return []
+    
+    # Find the end of the struct (next 'type' declaration or end of file)
+    next_type = content.find('\ntype ', struct_start + 1)
+    if next_type == -1:
+        struct_content = content[struct_start:]
+    else:
+        struct_content = content[struct_start:next_type]
+    
+    # Find dependencies
+    dependencies = []
+    for other_type in all_types:
+        if other_type == struct_name:
+            continue
+        
+        # Look for field declarations that use other custom types
+        # Enhanced patterns to handle complex type references:
+        # - Simple: FieldName Type
+        # - Array: FieldName []Type
+        # - Pointer: FieldName *Type  
+        # - Pointer to array: FieldName *[]Type
+        # - Array of pointers: FieldName []*Type
+        patterns = [
+            rf'\s+\w+\s+{re.escape(other_type)}(\s|$|\`)',           # FieldName Type
+            rf'\s+\w+\s+\[\]{re.escape(other_type)}(\s|$|\`)',       # FieldName []Type
+            rf'\s+\w+\s+\*{re.escape(other_type)}(\s|$|\`)',         # FieldName *Type
+            rf'\s+\w+\s+\*\[\]{re.escape(other_type)}(\s|$|\`)',     # FieldName *[]Type
+            rf'\s+\w+\s+\[\]\*{re.escape(other_type)}(\s|$|\`)',     # FieldName []*Type
+        ]
+        
+        for pattern in patterns:
+            if re.search(pattern, struct_content):
+                dependencies.append(other_type)
+                break  # Found this type, no need to check other patterns
+    
+    return dependencies
+
+
+def find_struct_dependencies_across_files(files_data, struct_name, all_types):
+    """Find dependencies for a struct across all cloudmodel files."""
+    dependencies = []
+    source_file = None
+    
+    # First, find which file contains this struct
+    for filename, data in files_data.items():
+        if struct_name in data['structs']:
+            source_file = filename
+            dependencies = find_struct_dependencies_in_content(data['content'], struct_name, all_types)
+            break
+    
+    return dependencies, source_file
+
+
+def find_references_to_struct_across_files(files_data, target_struct):
+    """Find which structs reference the target struct across all files."""
+    references = []
+    
+    for filename, data in files_data.items():
+        for struct_name in data['structs']:
+            if struct_name == target_struct:
+                continue
+            
+            # Extract the struct definition
+            content = data['content']
+            struct_start = content.find(f'type {struct_name} struct')
+            if struct_start == -1:
+                continue
+            
+            next_type = content.find('\ntype ', struct_start + 1)
+            if next_type == -1:
+                struct_content = content[struct_start:]
+            else:
+                struct_content = content[struct_start:next_type]
+            
+            # Check if this struct references the target struct
+            # Enhanced patterns to handle complex type references:
+            patterns = [
+                rf'\s+\w+\s+{re.escape(target_struct)}(\s|$|\`)',           # FieldName Type
+                rf'\s+\w+\s+\[\]{re.escape(target_struct)}(\s|$|\`)',       # FieldName []Type
+                rf'\s+\w+\s+\*{re.escape(target_struct)}(\s|$|\`)',         # FieldName *Type
+                rf'\s+\w+\s+\*\[\]{re.escape(target_struct)}(\s|$|\`)',     # FieldName *[]Type
+                rf'\s+\w+\s+\[\]\*{re.escape(target_struct)}(\s|$|\`)',     # FieldName []*Type
+            ]
+            
+            found = False
+            for pattern in patterns:
+                if re.search(pattern, struct_content):
+                    references.append((struct_name, filename))
+                    found = True
+                    break
+            
+            if found:
+                continue
+    
+    return references
+
+
+def check_usage_in_file(file_path, struct_names):
+    """Check which structs are used in a specific file."""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        used_structs = []
+        for struct_name in struct_names:
+            if struct_name in content:
+                used_structs.append(struct_name)
+        
+        return used_structs
+    except FileNotFoundError:
+        return []
+
+
+def analyze_dependencies(verbose=False, unused_only=False):
+    """Main analysis function."""
+    project_root = find_project_root()
+    
+    # Read all cloudmodel package files
+    files_data, all_structs, all_string_types, all_types = read_cloudmodel_files(project_root)
+    
+    if not files_data:
+        print("❌ Error: No cloudmodel files found!")
+        return 1
+    
+    print("🔍 CB-Tumblebug Model Dependency Analysis (CloudModel Package)")
+    print("=" * 65)
+    
+    if not unused_only:
+        print(f"\n📊 Statistics:")
+        print(f"   Total files analyzed: {len(files_data)}")
+        for filename, data in files_data.items():
+            print(f"   {filename}: {len(data['structs'])} structs, {len(data['string_types'])} string types")
+        print(f"   Package total: {len(all_structs)} structs, {len(all_string_types)} string types, {len(all_types)} custom types")
+        
+        if verbose:
+            print(f"\n� Files analyzed:")
+            for filename, data in files_data.items():
+                print(f"   • {filename} ({data['description']})")
+                if data['structs']:
+                    struct_list = ", ".join(sorted(data['structs']))
+                    print(f"     Structs: {struct_list}")
+                if data['string_types']:
+                    types_list = ", ".join(sorted(data['string_types']))
+                    print(f"     Types: {types_list}")
+    
+    # Analyze dependencies across all files
+    struct_dependencies = {}
+    struct_files = {}  # Track which file each struct is defined in
+    
+    for struct_name in all_structs:
+        dependencies, source_file = find_struct_dependencies_across_files(files_data, struct_name, all_types)
+        struct_dependencies[struct_name] = dependencies
+        struct_files[struct_name] = source_file
+    
+    # Find unreferenced structs: Check copied-tb-model.go structs for any references
+    # across all files (copied-tb-model.go, model.go, vm-infra-info.go)
+    unreferenced_structs = []
+    
+    # Get copied-tb-model.go data
+    copied_tb_data = files_data.get('copied-tb-model.go')
+    if copied_tb_data:
+        copied_tb_structs = copied_tb_data['structs']
+        
+        # Check each struct in copied-tb-model.go for any references in the entire package
+        for struct_name in copied_tb_structs:
+            references = find_references_to_struct_across_files(files_data, struct_name)
+            if not references:
+                unreferenced_structs.append(struct_name)
+    
+    # Note: Only copied-tb-model.go structs are checked for unreferenced status
+    # model.go and vm-infra-info.go structs are excluded as they are external API models
+    
+    if unused_only:
+        print(f"\n⚠️  UNREFERENCED STRUCTS (not used by any other struct) [{len(unreferenced_structs)}]:")
+        if unreferenced_structs:
+            # Only copied-tb-model.go structs are checked for unreferenced status
+            copied_tb_unreferenced = [s for s in unreferenced_structs if struct_files[s] == 'copied-tb-model.go']
+            
+            if copied_tb_unreferenced:
+                print(f"\n   📄 From copied-tb-model.go (no references across all files):")
+                for struct in sorted(copied_tb_unreferenced):
+                    print(f"      • {struct}")
+            else:
+                print("   No unreferenced structs found in copied-tb-model.go.")
+        else:
+            print("   No unreferenced structs found.")
+        
+        if verbose:
+            print(f"\n💡 Analysis method:")
+            print(f"   - copied-tb-model.go: Check references across all files (copied-tb-model.go, model.go, vm-infra-info.go)")
+            print(f"   - model.go & vm-infra-info.go: Excluded from unreferenced analysis (external API models)")
+        
+        return 0
+    
+    # Separate all structs into referenced and unreferenced categories
+    referenced_structs = []
+    truly_unreferenced_structs = []
+    
+    for struct_name in all_structs:
+        references = find_references_to_struct_across_files(files_data, struct_name)
+        source_file = struct_files[struct_name]
+        
+        if references:
+            referenced_structs.append((struct_name, source_file, references))
+        else:
+            # Only include copied-tb-model.go structs in truly unreferenced
+            # (model.go and vm-infra-info.go structs are external API models)
+            if source_file == 'copied-tb-model.go':
+                truly_unreferenced_structs.append(struct_name)
+    
+    # Display referenced structs, prioritizing copied-tb-model.go
+    copied_tb_referenced = []
+    other_referenced = []
+    
+    for struct_name, source_file, references in referenced_structs:
+        if source_file == 'copied-tb-model.go':
+            copied_tb_referenced.append((struct_name, source_file, references))
+        else:
+            other_referenced.append((struct_name, source_file, references))
+    
+    print(f"\n✅ REFERENCED STRUCTS (used by other structs) [{len(copied_tb_referenced)}]:")
+    
+    if copied_tb_referenced:
+        print(f"\n   📄 From copied-tb-model.go:")
+        for struct_name, source_file, references in copied_tb_referenced:
+            ref_details = []
+            for ref_struct, ref_file in references:
+                if ref_file == 'copied-tb-model.go':
+                    ref_details.append(ref_struct)
+                else:
+                    ref_details.append(f"{ref_struct} ({ref_file})")
+            ref_str = ", ".join(ref_details)
+            print(f"      • {struct_name} ← {ref_str}")
+    else:
+        print("   No referenced structs found in copied-tb-model.go.")
+    
+    print(f"\n🏝️  UNREFERENCED STRUCTS (not used by other structs) [{len(truly_unreferenced_structs)}]:")
+    if truly_unreferenced_structs:
+        print(f"   📄 From copied-tb-model.go:")
+        for struct in sorted(truly_unreferenced_structs):
+            print(f"      • {struct}")
+    else:
+        print("   No unreferenced structs found in copied-tb-model.go.")
+    
+    if verbose:
+        print(f"\n📈 Detailed Dependency Analysis:")
+        
+        # Special analysis for copied-tb-model.go structs
+        copied_tb_data = files_data.get('copied-tb-model.go')
+        if copied_tb_data:
+            print(f"\n   🔍 Internal Dependencies within copied-tb-model.go:")
+            copied_tb_structs = copied_tb_data['structs']
+            copied_tb_types = copied_tb_data['types']
+            
+            for struct_name in sorted(copied_tb_structs):
+                internal_dependencies = find_struct_dependencies_in_content(
+                    copied_tb_data['content'], struct_name, copied_tb_types
+                )
+                external_references = find_references_to_struct_across_files(files_data, struct_name)
+                
+                print(f"\n      🔸 {struct_name}:")
+                print(f"         Internal dependencies: {internal_dependencies if internal_dependencies else 'None'}")
+                if external_references:
+                    ref_details = [f"{ref_struct} ({ref_file})" for ref_struct, ref_file in external_references]
+                    print(f"         External references: {ref_details}")
+                else:
+                    print(f"         External references: None")
+        
+        # Regular analysis for all other structs
+        print(f"\n   📊 All Structs Analysis:")
+        for struct_name in sorted(all_structs):
+            if struct_files[struct_name] == 'copied-tb-model.go':
+                continue  # Already analyzed above
+                
+            dependencies = struct_dependencies[struct_name]
+            references = find_references_to_struct_across_files(files_data, struct_name)
+            source_file = struct_files[struct_name]
+            
+            print(f"\n      🔸 {struct_name} (defined in {source_file}):")
+            print(f"         Dependencies: {dependencies if dependencies else 'None'}")
+            if references:
+                ref_details = [f"{ref_struct} ({ref_file})" for ref_struct, ref_file in references]
+                print(f"         Referenced by: {ref_details}")
+            else:
+                print(f"         Referenced by: None")
+    
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze struct dependencies in CB-Tumblebug model files",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python3 scripts/analyze_dependencies.py                    # Basic analysis
+  python3 scripts/analyze_dependencies.py --verbose          # Detailed analysis
+  python3 scripts/analyze_dependencies.py --unused-only      # Show only unreferenced structs
+        """
+    )
+    
+    parser.add_argument(
+        '--verbose', '-v',
+        action='store_true',
+        help='Show detailed dependency information'
+    )
+    
+    parser.add_argument(
+        '--unused-only', '-u',
+        action='store_true',
+        help='Show only unreferenced structs (not used by other structs)'
+    )
+    
+    args = parser.parse_args()
+    
+    try:
+        return analyze_dependencies(
+            verbose=args.verbose, 
+            unused_only=args.unused_only
+        )
+    except KeyboardInterrupt:
+        print("\n\n⚠️  Analysis interrupted by user")
+        return 1
+    except Exception as e:
+        print(f"\n❌ Error during analysis: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR will update the cloud model.

* Sync structs of `copied-tb-model.go` to reflect the Tumblebug v0.11.9 update
* Add a Python script to check the dependency chain of the structs in `copied-tb-model.go`
* Add `TargetCloud` property to the RecommendVmInfraModel
