### PR TITLE
improve(context): sync models with Tumblebug

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -135,6 +135,8 @@ cm-model/
 
 - **Automated Synchronization**: Use SyncTB prompt file (`.github/prompts/sync-tb.prompt.md`) for TB model updates
 - **Version-Specific Updates**: Always specify target TB version when running SyncTB
+- **Git Diff as Source of Truth**: Always use git diff output as the authoritative source for struct changes
+- **Single Source of Truth**: [copied-tb-model.go](infra/cloud-model/copied-tb-model.go) is the only source for TB model definitions
 - **Change Validation**: Review all struct changes for backward compatibility before applying
 - **Documentation Preservation**: Maintain all existing field comments and validation patterns
 - **Testing Requirements**: Verify model serialization and ensure no compilation errors after sync
@@ -214,79 +216,23 @@ type PackageMigrationInfo struct {
 }
 ```
 
-### CB-Tumblebug Model Patterns
+### CB-Tumblebug Model Reference
 
-```go
-// MCI (Multi Cloud Infrastructure) Request Pattern
-type TbMciReq struct {
-    Name            string            `json:"name" validate:"required" example:"mci01"`
-    InstallMonAgent string            `json:"installMonAgent" example:"no" default:"no" enums:"yes,no"`
-    Label           map[string]string `json:"label"`
-    SystemLabel     string            `json:"systemLabel" example:"" default:""`
-    PlacementAlgo   string            `json:"placementAlgo,omitempty"`
-    Description     string            `json:"description" example:"Made in CB-TB"`
-    Vm              []TbVmReq         `json:"vm" validate:"required"`
-    PostCommand     MciCmdReq         `json:"postCommand" validate:"omitempty"`
-}
-```
+CB-Tumblebug models are maintained in [infra/cloud-model/copied-tb-model.go](infra/cloud-model/copied-tb-model.go). This file contains complete struct definitions with comprehensive documentation, validation tags, and examples synchronized from the CB-Tumblebug framework.
 
-```go
-// VM Request Pattern with CSP Resource Management
-type TbVmReq struct {
-    Name             string   `json:"name" validate:"required" example:"g1-1"`
-    CspResourceId    string   `json:"cspResourceId,omitempty" example:"i-014fa6ede6ada0b2c"`
-    SubGroupSize     string   `json:"subGroupSize" example:"3" default:""`
-    Label            map[string]string `json:"label"`
-    Description      string   `json:"description" example:"Description"`
-    ConnectionName   string   `json:"connectionName" validate:"required" example:"testcloud01-seoul"`
-    SpecId           string   `json:"specId" validate:"required"`
-    ImageId          string   `json:"imageId" validate:"required"`
-    VNetId           string   `json:"vNetId" validate:"required"`
-    SubnetId         string   `json:"subnetId" validate:"required"`
-    SecurityGroupIds []string `json:"securityGroupIds" validate:"required"`
-    SshKeyId         string   `json:"sshKeyId" validate:"required"`
-    VmUserName       string   `json:"vmUserName,omitempty"`
-    VmUserPassword   string   `json:"vmUserPassword,omitempty"`
-    RootDiskType     string   `json:"rootDiskType,omitempty" example:"default, TYPE1, ..."`
-    RootDiskSize     string   `json:"rootDiskSize,omitempty" example:"default, 30, 42, ..."`
-    DataDiskIds      []string `json:"dataDiskIds"`
-}
-```
+**Key Model Categories**:
 
-```go
-// Dynamic Resource Pattern with Common Specs
-type TbVmDynamicReq struct {
-    Name             string            `json:"name" example:"g1-1"`
-    SubGroupSize     string            `json:"subGroupSize" example:"3" default:"1"`
-    Label            map[string]string `json:"label"`
-    Description      string            `json:"description" example:"Description"`
-    CommonSpec       string            `json:"commonSpec" validate:"required" example:"aws+ap-northeast-2+t2.small"`
-    CommonImage      string            `json:"commonImage" validate:"required" example:"ubuntu18.04"`
-    RootDiskType     string            `json:"rootDiskType,omitempty" example:"default, TYPE1, ..." default:"default"`
-    RootDiskSize     string            `json:"rootDiskSize,omitempty" example:"default, 30, 42, ..." default:"default"`
-    VmUserPassword   string            `json:"vmUserPassword,omitempty" default:""`
-    ConnectionName   string            `json:"connectionName,omitempty" default:""`
-}
-```
+- **MCI (Multi-Cloud Infrastructure)**: `TbMciReq`, `TbMciInfo` - Multi-cloud infrastructure deployment and management
+- **VM Resources**: `TbVmReq`, `TbVmInfo`, `TbVmDynamicReq` - Virtual machine configurations and specifications
+- **Network Resources**: `TbVNetReq`, `TbSubnetReq`, `TbSecurityGroupReq` - Network infrastructure and security
+- **Supporting Types**: `TbFirewallRuleInfo`, `KeyValue`, `RegionInfo` - Common utility types
 
-```go
-// Network Security Pattern with Firewall Rules
-type TbSecurityGroupReq struct {
-    Name           string                `json:"name" validate:"required"`
-    ConnectionName string                `json:"connectionName" validate:"required"`
-    VNetId         string                `json:"vNetId" validate:"required"`
-    Description    string                `json:"description"`
-    FirewallRules  *[]TbFirewallRuleInfo `json:"firewallRules"`
-    CspResourceId  string                `json:"cspResourceId" example:"required for option=register only"`
-}
+**Important Notes**:
 
-type TbFirewallRuleInfo struct {
-    Ports     string `json:"Ports" example:"1-65535,22,5555"`
-    Protocol  string `validate:"required" json:"Protocol" example:"TCP" enums:"TCP,UDP,ICMP,ALL"`
-    Direction string `validate:"required" json:"Direction" example:"inbound" enums:"inbound,outbound"`
-    CIDR      string `json:"CIDR" example:"0.0.0.0/0"`
-}
-```
+- All TB models include complete field documentation and examples from CB-Tumblebug source
+- Struct definitions are synchronized with specific CB-Tumblebug versions (check file header for current version)
+- Field types may change across TB versions during synchronization
+- For latest model definitions, always refer to [copied-tb-model.go](infra/cloud-model/copied-tb-model.go)
 
 ## Usage Examples
 
@@ -385,13 +331,11 @@ The SyncTB tool provides automated CB-Tumblebug model synchronization through VS
 **How to Use SyncTB**:
 
 1. **Via Chat Command**:
-
    - Open VS Code Chat (Ctrl+Shift+I or Cmd+Shift+I)
    - Type `/sync-tb` in the chat input
    - Specify the target TB version when prompted (e.g., `v0.11.2`, `v0.12.0`, `latest`)
 
 2. **Via Command Palette**:
-
    - Open Command Palette (Ctrl+Shift+P or Cmd+Shift+P)
    - Run "Chat: Run Prompt"
    - Select "sync-tb" from the list

--- a/.github/prompts/sync-tb.prompt.md
+++ b/.github/prompts/sync-tb.prompt.md
@@ -132,6 +132,8 @@ Execute git diff commands directly:
 
 Directly apply identified changes to copied-tb-model.go:
 
+- **CRITICAL**: Use ONLY git diff output as the source of truth for all struct changes
+- **Single Source**: copied-tb-model.go is the only maintained source for TB model definitions
 - **Use `replace_string_in_file`** to update struct definitions
 - Apply field additions, removals, and type changes from git diff
 - Update validation tags and JSON serialization tags
@@ -217,7 +219,6 @@ For each existing struct, identify all struct-type fields:
 - **Use `get_terminal_output`** to capture complete diff output for each file
 - **Use `grep_search`** to identify specific struct definitions and field patterns
 - Parse diff hunks to identify:
-
   - Added lines (prefixed with `+`)
   - Removed lines (prefixed with `-`)
   - Context lines for struct identification
@@ -306,18 +307,19 @@ Update the header comment in copied-tb-model.go to include commit hash:
 
 For EVERY struct that exists in copied-tb-model.go AND appears in git diff:
 
-1. **Name Change Detection**: Check if struct name has changed (e.g., `TbMciReq` → `MciReq`)
-2. **Complete Replacement**: If name changed, replace entire struct definition with new name and content
-3. **Field Additions**: Add ALL new fields exactly as shown in git diff `+` lines
-4. **Field Removals**: Remove ALL fields shown in git diff `-` lines
-5. **Field Modifications**: Update ALL field types, tags, and comments based on diff changes
-6. **Type Reference Updates**: Update field types when referenced struct names change
-7. **Validation Tag Updates**: Apply ALL validation tag changes (`validate:"required"`, etc.)
-8. **JSON Tag Updates**: Update ALL JSON serialization tags (`json:"fieldName"`, `omitempty`)
-9. **Example Updates**: Update ALL struct tag examples to match TB source
-10. **Comment Preservation**: Maintain ALL existing Tumblebug field documentation and examples
-11. **Header Update**: Update version header with target version and commit hash
-12. **Documentation**: Preserve clear struct names and descriptions without path references
+1. **Git Diff as Source**: Use ONLY git diff output for struct changes (single source of truth)
+2. **Name Change Detection**: Check if struct name has changed (e.g., `TbMciReq` → `MciReq`)
+3. **Complete Replacement**: If name changed, replace entire struct definition with new name and content
+4. **Field Additions**: Add ALL new fields exactly as shown in git diff `+` lines
+5. **Field Removals**: Remove ALL fields shown in git diff `-` lines
+6. **Field Modifications**: Update ALL field types, tags, and comments based on diff changes
+7. **Type Reference Updates**: Update field types when referenced struct names change
+8. **Validation Tag Updates**: Apply ALL validation tag changes (`validate:"required"`, etc.)
+9. **JSON Tag Updates**: Update ALL JSON serialization tags (`json:"fieldName"`, `omitempty`)
+10. **Example Updates**: Update ALL struct tag examples to match TB source
+11. **Comment Preservation**: Maintain ALL existing Tumblebug field documentation and examples
+12. **Header Update**: Update version header with target version and commit hash
+13. **Documentation**: Preserve clear struct names and descriptions without path references
 
 #### E. Dependency Struct Addition
 
@@ -404,6 +406,9 @@ Follow the patterns and guidelines defined in:
 
 - [copilot-instructions.md](../../copilot-instructions.md) - CB-Tumblebug Integration section
 - [TB Synchronization Guidelines](../../copilot-instructions.md#cb-tumblebug-model-updates)
+- [copied-tb-model.go](../../infra/cloud-model/copied-tb-model.go) - Current synchronized TB models (single source of truth)
+
+**⚠️ CRITICAL**: **ALWAYS** use git diff output as the authoritative source for struct changes during synchronization. Do not rely on documentation or external references for struct definitions.
 
 ## Important Notes
 


### PR DESCRIPTION
- Added explicit guidance: git diff is the authoritative source for all struct changes
- Clarified that copied-tb-model.go is the single maintained source for TB models
- Updated SyncTB struct synchronization checklist with git diff priority (step 1)
- Excluded specific Tumblebug model pattern samples and referred to copied-tb-model.go